### PR TITLE
fix multi_GPU training, support pytorch2.0

### DIFF
--- a/mel_processing.py
+++ b/mel_processing.py
@@ -64,7 +64,7 @@ def spectrogram_torch(y, n_fft, sampling_rate, hop_size, win_size, center=False)
     y = y.squeeze(1)
 
     spec = torch.stft(y, n_fft, hop_length=hop_size, win_length=win_size, window=hann_window[wnsize_dtype_device],
-                      center=center, pad_mode='reflect', normalized=False, onesided=True)
+                      center=center, pad_mode='reflect', normalized=False, onesided=True, return_complex=False)
 
     spec = torch.sqrt(spec.pow(2).sum(-1) + 1e-6)
     return spec
@@ -102,7 +102,7 @@ def mel_spectrogram_torch(y, n_fft, num_mels, sampling_rate, hop_size, win_size,
     y = y.squeeze(1)
 
     spec = torch.stft(y, n_fft, hop_length=hop_size, win_length=win_size, window=hann_window[wnsize_dtype_device],
-                      center=center, pad_mode='reflect', normalized=False, onesided=True)
+                      center=center, pad_mode='reflect', normalized=False, onesided=True, return_complex=False)
 
     spec = torch.sqrt(spec.pow(2).sum(-1) + 1e-6)
 

--- a/mel_processing.py
+++ b/mel_processing.py
@@ -1,5 +1,6 @@
 import math
 import os
+from packaging import version
 import random
 import torch
 from torch import nn
@@ -63,9 +64,13 @@ def spectrogram_torch(y, n_fft, sampling_rate, hop_size, win_size, center=False)
     y = torch.nn.functional.pad(y.unsqueeze(1), (int((n_fft-hop_size)/2), int((n_fft-hop_size)/2)), mode='reflect')
     y = y.squeeze(1)
 
-    spec = torch.stft(y, n_fft, hop_length=hop_size, win_length=win_size, window=hann_window[wnsize_dtype_device],
-                      center=center, pad_mode='reflect', normalized=False, onesided=True, return_complex=False)
-
+    if version.parse(torch.____version__) >= version.parse("2"):
+        spec = torch.stft(y, n_fft, hop_length=hop_size, win_length=win_size, window=hann_window[wnsize_dtype_device],
+                          center=center, pad_mode='reflect', normalized=False, onesided=True, return_complex=False)
+    else:
+        spec = torch.stft(y, n_fft, hop_length=hop_size, win_length=win_size, window=hann_window[wnsize_dtype_device],
+                      center=center, pad_mode='reflect', normalized=False, onesided=True)
+        
     spec = torch.sqrt(spec.pow(2).sum(-1) + 1e-6)
     return spec
 
@@ -101,8 +106,12 @@ def mel_spectrogram_torch(y, n_fft, num_mels, sampling_rate, hop_size, win_size,
     y = torch.nn.functional.pad(y.unsqueeze(1), (int((n_fft-hop_size)/2), int((n_fft-hop_size)/2)), mode='reflect')
     y = y.squeeze(1)
 
-    spec = torch.stft(y, n_fft, hop_length=hop_size, win_length=win_size, window=hann_window[wnsize_dtype_device],
-                      center=center, pad_mode='reflect', normalized=False, onesided=True, return_complex=False)
+    if version.parse(torch.____version__) >= version.parse("2"):
+        spec = torch.stft(y, n_fft, hop_length=hop_size, win_length=win_size, window=hann_window[wnsize_dtype_device],
+                          center=center, pad_mode='reflect', normalized=False, onesided=True, return_complex=False)
+    else:
+        spec = torch.stft(y, n_fft, hop_length=hop_size, win_length=win_size, window=hann_window[wnsize_dtype_device],
+                      center=center, pad_mode='reflect', normalized=False, onesided=True)
 
     spec = torch.sqrt(spec.pow(2).sum(-1) + 1e-6)
 

--- a/train.py
+++ b/train.py
@@ -12,6 +12,7 @@ import torch.multiprocessing as mp
 import torch.distributed as dist
 from torch.nn.parallel import DistributedDataParallel as DDP
 from torch.cuda.amp import autocast, GradScaler
+import tqdm
 
 import commons
 import utils
@@ -120,10 +121,6 @@ def run(rank, n_gpus, hps):
       len(symbols),
       posterior_channels,
       hps.train.segment_size // hps.data.hop_length,
-      use_transformer_flows=use_transformer_flows,
-      transformer_flow_type=transformer_flow_type,
-      use_spk_conditioned_encoder=use_spk_conditioned_encoder,
-      use_noise_scaled_mas=use_noise_scaled_mas,
       mas_noise_scale_initial = mas_noise_scale_initial,
       noise_scale_delta = noise_scale_delta,
       **hps.model).cuda(rank)
@@ -176,7 +173,11 @@ def train_and_evaluate(rank, epoch, hps, nets, optims, schedulers, scaler, loade
   
   net_g.train()
   net_d.train()
-  for batch_idx, (x, x_lengths, spec, spec_lengths, y, y_lengths) in enumerate(train_loader):
+  if rank == 0:
+      loader = tqdm.tqdm(train_loader, desc='Loading train data')
+  else:
+      loader = train_loader
+  for batch_idx, (x, x_lengths, spec, spec_lengths, y, y_lengths) in enumerate(loader):
     if net_g.use_noise_scaled_mas:
       current_mas_noise_scale = net_g.module.mas_noise_scale_initial - net_g.module.noise_scale_delta * global_step
       net_g.module.current_mas_noise_scale = max(current_mas_noise_scale, 0.0)


### PR DESCRIPTION
- Some parameters have already written in hps.model (vits2_vctk_base.json), these would cause error `TypeError: type object got multiple values for keyword argument 'use_transformer_flows'`
- Set return_complex to False in order to enable training in PyTorch 2.0. This change is necessary due to PyTorch 2.0 modifying the default value in stft from False to True.
- Add a tqdm progress bar