### PR TITLE
fix: librosa and requirements

### DIFF
--- a/mel_processing.py
+++ b/mel_processing.py
@@ -80,7 +80,7 @@ def spec_to_mel_torch(spec, n_fft, num_mels, sampling_rate, fmin, fmax):
     dtype_device = str(spec.dtype) + '_' + str(spec.device)
     fmax_dtype_device = str(fmax) + '_' + dtype_device
     if fmax_dtype_device not in mel_basis:
-        mel = librosa_mel_fn(sampling_rate, n_fft, num_mels, fmin, fmax)
+        mel = librosa_mel_fn(sr=sampling_rate, n_fft=n_fft, n_mels=num_mels, fmin=fmin, fmax=fmax)
         mel_basis[fmax_dtype_device] = torch.from_numpy(mel).to(dtype=spec.dtype, device=spec.device)
     spec = torch.matmul(mel_basis[fmax_dtype_device], spec)
     spec = spectral_normalize_torch(spec)
@@ -98,7 +98,7 @@ def mel_spectrogram_torch(y, n_fft, num_mels, sampling_rate, hop_size, win_size,
     fmax_dtype_device = str(fmax) + '_' + dtype_device
     wnsize_dtype_device = str(win_size) + '_' + dtype_device
     if fmax_dtype_device not in mel_basis:
-        mel = librosa_mel_fn(sampling_rate, n_fft, num_mels, fmin, fmax)
+        mel = librosa_mel_fn(sr=sampling_rate, n_fft=n_fft, n_mels=num_mels, fmin=fmin, fmax=fmax)
         mel_basis[fmax_dtype_device] = torch.from_numpy(mel).to(dtype=y.dtype, device=y.device)
     if wnsize_dtype_device not in hann_window:
         hann_window[wnsize_dtype_device] = torch.hann_window(win_size).to(dtype=y.dtype, device=y.device)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,11 @@
-Cython==0.29.21
-librosa==0.8.0
-matplotlib==3.3.1
-numpy==1.18.5
-phonemizer==2.2.1
-scipy==1.5.2
-torch==1.13.1
-torchvision==0.14.1
-Unidecode==1.1.1
-tensorboardX
+Cython==3.0.2
+librosa==0.10.1
+matplotlib==3.7.2
+numpy==1.24.4
+phonemizer==3.2.1
+scipy==1.11.2
+# torch==2.0.1
+# torchaudio==2.0.2
+# torchvision==0.15.2
+Unidecode==1.3.6
+tensorboard==2.14.0


### PR DESCRIPTION
Hello!

The existing versions of Numpy and Librosa in the repository are outdated, leading to installation challenges. I've updated the mel extraction function to ensure compatibility with the newer versions of Librosa. Additionally, I've bumped the versions of both Numpy, Cython, phonemizer and Scipy.

The specific change can be found in mel_processing.py

Previously, the code was:

````
mel = librosa_mel_fn(sampling_rate, n_fft, num_mels, fmin, fmax)
````

I've modified it to:

````
mel = librosa_mel_fn(sr=sampling_rate, n_fft=n_fft, n_mels=num_mels, fmin=fmin, fmax=fmax)
````

Thanks for considering my changes!